### PR TITLE
muliplied by temperature in szmap function

### DIFF
--- a/tutorials/aperture.ipynb
+++ b/tutorials/aperture.ipynb
@@ -166,7 +166,7 @@
     "ys = 10**logys\n",
     "\n",
     "def szmap(ymap,nu_ghz,tcmb=2.7255):\n",
-    "    return gnu(nu_ghz,tcmb)*ymap*tcmb*e6\n",
+    "    return gnu(nu_ghz,tcmb)*ymap*tcmb*1e6\n",
     "\n",
     "\n",
     "# Example simulated SZ map\n",

--- a/tutorials/aperture.ipynb
+++ b/tutorials/aperture.ipynb
@@ -166,7 +166,7 @@
     "ys = 10**logys\n",
     "\n",
     "def szmap(ymap,nu_ghz,tcmb=2.7255):\n",
-    "    return gnu(nu_ghz,tcmb)*ymap*1e6\n",
+    "    return gnu(nu_ghz,tcmb)*ymap*2.7255e6\n",
     "\n",
     "\n",
     "# Example simulated SZ map\n",

--- a/tutorials/aperture.ipynb
+++ b/tutorials/aperture.ipynb
@@ -166,7 +166,7 @@
     "ys = 10**logys\n",
     "\n",
     "def szmap(ymap,nu_ghz,tcmb=2.7255):\n",
-    "    return gnu(nu_ghz,tcmb)*ymap*2.7255e6\n",
+    "    return gnu(nu_ghz,tcmb)*ymap*tcmb*e6\n",
     "\n",
     "\n",
     "# Example simulated SZ map\n",


### PR DESCRIPTION
I changed the szmap function so it multiplies g(nu) by Tcmbe6 instead of 1e6.