### PR TITLE
Replace deprecated np.int with builtin int

### DIFF
--- a/orphics/catalogs.py
+++ b/orphics/catalogs.py
@@ -78,7 +78,7 @@ class Pow2Cat(object):
         sampled = np.random.poisson(ngalmap).astype(np.float64)
         Ny,Nx = self.shape[-2:]
         pixmap = (enmap.pixmap(self.shape,self.wcs)).reshape(2,Ny*Nx)
-        nobjs = sampled.reshape(-1).astype(np.int)
+        nobjs = sampled.reshape(-1).astype(int)
         cat = np.repeat(pixmap,nobjs,-1).astype(np.float64)
         jitter = np.random.uniform(-0.5,0.5,size=cat.shape) if add_jitter else 0.
         cat += jitter
@@ -494,7 +494,7 @@ def select_based_on_mask(ras,decs,mask,threshold=0.99):
     Filters ra,dec based on whether it falls within a mask
     """
     coords = np.vstack((decs,ras))*np.pi/180.
-    pixs = enmap.sky2pix(mask.shape,mask.wcs,coords).astype(np.int)
+    pixs = enmap.sky2pix(mask.shape,mask.wcs,coords).astype(int)
     # First select those that fall within geometry
     sel = np.logical_and.reduce([pixs[0]>=0,pixs[1]>=0,pixs[0]<mask.shape[0],pixs[1]<mask.shape[1]])
     pixs = pixs[:,sel]
@@ -587,7 +587,7 @@ def hp_from_mangle(weight_ply_files,nside=None,veto_ply_files=None,hp_coords='eq
 
     if coords is None:
         npix = hp.nside2npix(nside)
-        pixs = np.arange(npix,dtype=np.int)
+        pixs = np.arange(npix,dtype=int)
         if verbose: print("Converting healpix pixels to coordinates.")
         ra,dec = hp.pix2ang(nside,pixs,lonlat=True)
 

--- a/orphics/maps.py
+++ b/orphics/maps.py
@@ -506,7 +506,7 @@ def cutup(shape,numy,numx,pad=0):
     boxes[:,0,1][boxes[:,0,1]<0] = 0
     boxes[:,1,1] = np.repeat(pixs_x[1:],numy) + pad
     boxes[:,1,1][boxes[:,1,1]>(Nx-1)] = Nx-1
-    boxes = boxes.astype(np.int)
+    boxes = boxes.astype(int)
 
     return boxes
 
@@ -578,7 +578,7 @@ def downsample_power(shape,wcs,cov,ndown=16,order=0,exp=None,fftshift=True,fft=F
         dshape = np.array(cov.shape)
         dshape[-2] /= ndown[0]
         dshape[-1] /= ndown[1]
-        cov_low = resample.resample_fft(afftshift(cov), dshape.astype(np.int))
+        cov_low = resample.resample_fft(afftshift(cov), dshape.astype(int))
     else:
         cov_low = enmap.downgrade(afftshift(cov), ndown)
     if not(fft_up):
@@ -986,7 +986,7 @@ def gauss_beam_real(rs,fwhm):
 
 
 def mask_kspace(shape,wcs, lxcut = None, lycut = None, lmin = None, lmax = None):
-    output = enmap.ones(shape[-2:],wcs, dtype = np.int)
+    output = enmap.ones(shape[-2:],wcs, dtype = int)
     if (lmin is not None) or (lmax is not None): modlmap = enmap.modlmap(shape, wcs)
     if (lxcut is not None) or (lycut is not None): ly, lx = enmap.laxes(shape, wcs, oversample=1)
     if lmin is not None:
@@ -1317,7 +1317,7 @@ def inpaint_cg(imap,rand_map,mask,power2d,eps=1.e-8):
         alpha=delta_new/(np.inner(d,q))
         x=x+alpha*d
         
-        if i/50.<np.int(i/50):
+        if i/50.<int(i/50):
             
             r=b-apply_px_c_inv_px(x)
         else:


### PR DESCRIPTION
`np.int` shows up several times in `orphics.catalogs` and `orphics.maps`, but this was deprecated in numpy 1.20, so this PR  simply changes these to `int`, which should not incur any change in behavior.